### PR TITLE
Make link work by adding https:// prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 [![Quarto Publish](https://github.com/PMassicotte/r-blog/actions/workflows/publish.yml/badge.svg)](https://github.com/PMassicotte/r-blog/actions/workflows/publish.yml)
 <!-- badges: end -->
 
-This is the git repository for my [R blog website](www.pmassicotte.com).
+This is the git repository for my [R blog website](https://www.pmassicotte.com).


### PR DESCRIPTION
The link expands to a _relative_ link as it lacks the usual http:// prefix I added.

Nice site :smiley: 